### PR TITLE
Add file (.log) connector for zero-infra anomaly detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .DS_Store
+
+# Draft docs — kept locally, not committed
+BLOG_anomaly_detection.md
+RELEASE_NOTES_v0.4.0.md

--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ Point it at any source you already use:
 curl 'http://localhost:9020/clusters?source=loki&window=1h'
 ```
 
+Or skip the credentials entirely — **download a log file and run it.** Export from Datadog (CSV/JSON), `kubectl logs > app.log`, or any raw log, drop it in, and analyse it locally:
+
+```bash
+curl -XPOST 'http://localhost:9020/clusters/train?source=file'   # FILE_PATH=/data/app.log
+```
+
+See the one-command [log-file quickstart](./example-setups/logfile-quickstart/).
+
 That's the whole install. No schemas to provision, no accounts to create, no agents on hosts.
 
 👉 **Deep dive:** [`ml/README.md`](./ml/README.md) for the ML engine · [`packages/otel-node`](./packages/otel-node) for the OTel agent
@@ -91,7 +99,7 @@ More examples (Fastify, NestJS, Next.js) are on the roadmap — PRs welcome.
 
 | Status | Platforms |
 | --- | --- |
-| ✅ Supported | OpenTelemetry · Loki · New Relic · Datadog · CloudWatch · Sentry · ClickHouse |
+| ✅ Supported | Log file (`.log`/`.json`/`.csv`) · OpenTelemetry · Loki · New Relic · Datadog · CloudWatch · Sentry · ClickHouse |
 | 🛣️ Roadmap | Splunk · Elastic / OpenSearch · Azure Monitor · GCP Cloud Logging |
 
 ## Community

--- a/example-setups/anomaly-detection-quickstart/README.md
+++ b/example-setups/anomaly-detection-quickstart/README.md
@@ -1,0 +1,34 @@
+# Anomaly detection quickstart
+
+A self-contained demo that shows the Rocketgraph ML pipeline in action against synthetic but realistic logs.
+
+It spins up:
+
+1. A local **ClickHouse** that holds the log stream.
+2. The **Rocketgraph ML** engine pointed at that ClickHouse.
+
+Then a seed script writes ~15k normal log lines plus an injected incident (a burst of `OOMKilled` errors and a brand-new `Database failover` template) so you can see the detector light up.
+
+## Run it
+
+```bash
+cd example-setups/anomaly-detection-quickstart
+docker compose up --build       # ClickHouse + Rocketgraph ML
+python seed_logs.py             # load synthetic logs into ClickHouse
+bash demo.sh                    # train, then score new logs
+```
+
+## What you'll see
+
+- `/clusters/train` returns ~10 to 15 Drain3 templates with one or two of them flagged as anomalies (the OOM burst and the failover template).
+- The inline `/anomalies/detect` call flags the OOM line as `anomaly_score` + `new_template`, ignores the boring login line.
+- The connector-fed `/anomalies/detect` reaches into ClickHouse, pulls the last hour, and returns only the rows the trained HST flagged.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `docker-compose.yml` | Brings up ClickHouse + the ML engine, wired together. |
+| `init-clickhouse.sql` | Creates `demo.logs` on first boot. |
+| `seed_logs.py` | Generates synthetic + injected-incident logs and INSERTs them. |
+| `demo.sh` | End-to-end calls against the ML API. |

--- a/example-setups/anomaly-detection-quickstart/demo.sh
+++ b/example-setups/anomaly-detection-quickstart/demo.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# End-to-end demo. Assumes:
+#   1. docker compose up   (ClickHouse + Rocketgraph ML running)
+#   2. python seed_logs.py (synthetic logs loaded into ClickHouse)
+#
+# Then run:  bash demo.sh
+#
+
+set -euo pipefail
+
+ML="http://localhost:9020"
+
+echo
+echo "==> 1. Cluster the last hour and train the streaming detector"
+echo
+curl -s -X POST "$ML/clusters/train?source=clickhouse&window=1h" | jq '{
+  log_count,
+  cluster_count,
+  anomalies: [.clusters[] | select(.isAnomaly == true) | {service, template, logCount, isolationDepth}]
+}'
+
+echo
+echo "==> 2. Score a brand-new log against the trained model"
+echo
+curl -s -X POST "$ML/anomalies/detect" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "logs": [
+          {
+            "timestamp": '"$(($(date +%s) * 1000))"',
+            "service":   "payment-svc",
+            "level":     "error",
+            "message":   "OOMKilled in payment-svc pod payment-9 container=stripe-worker memory=4096Mi"
+          },
+          {
+            "timestamp": '"$(($(date +%s) * 1000))"',
+            "service":   "auth-svc",
+            "level":     "info",
+            "message":   "User 4242 logged in from 10.0.0.1"
+          }
+        ]
+      }' | jq
+
+echo
+echo "==> 3. Fetch+score the most recent 5 minutes straight from ClickHouse"
+echo
+curl -s -X POST "$ML/anomalies/detect" \
+  -H "Content-Type: application/json" \
+  -d '{"source": "clickhouse", "window": "custom", "hours": 1}' | jq '{
+    source, scored, anomaly_count,
+    sample: (.anomalies[0:3])
+  }'

--- a/example-setups/anomaly-detection-quickstart/docker-compose.yml
+++ b/example-setups/anomaly-detection-quickstart/docker-compose.yml
@@ -1,0 +1,37 @@
+services:
+  clickhouse:
+    image: clickhouse/clickhouse-server:24.3
+    container_name: rg-demo-clickhouse
+    ports:
+      - "8123:8123"
+      - "9000:9000"
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    volumes:
+      - ./init-clickhouse.sql:/docker-entrypoint-initdb.d/init.sql:ro
+
+  ml:
+    image: rocketgraph-ml:latest
+    build:
+      context: ../../ml
+    container_name: rg-demo-ml
+    depends_on:
+      - clickhouse
+    ports:
+      - "9020:9020"
+    environment:
+      CH_URL: http://clickhouse:8123
+      CH_USER: default
+      CH_PASSWORD: ""
+      CH_DATABASE: demo
+      CH_TABLE: logs
+      CH_COL_TIMESTAMP: timestamp
+      CH_COL_MESSAGE: message
+      CH_COL_LEVEL: level
+      CH_COL_SERVICE: service
+      DRAIN_SIM_TH: "0.4"
+      HST_THRESHOLD: "0.7"
+      ANOMALY_CONTAMINATION: "0.1"
+      MAX_ROWS: "500000"

--- a/example-setups/anomaly-detection-quickstart/init-clickhouse.sql
+++ b/example-setups/anomaly-detection-quickstart/init-clickhouse.sql
@@ -1,0 +1,11 @@
+CREATE DATABASE IF NOT EXISTS demo;
+
+CREATE TABLE IF NOT EXISTS demo.logs
+(
+    timestamp DateTime64(3, 'UTC'),
+    service   LowCardinality(String),
+    level     LowCardinality(String),
+    message   String
+)
+ENGINE = MergeTree
+ORDER BY (service, timestamp);

--- a/example-setups/anomaly-detection-quickstart/seed_logs.py
+++ b/example-setups/anomaly-detection-quickstart/seed_logs.py
@@ -1,0 +1,144 @@
+"""
+Generates a fake but realistic log stream and loads it into ClickHouse.
+
+The stream has three services and looks roughly like a real production hour:
+  - 95% boring INFO traffic (logins, GETs, cache hits, queue acks)
+  - a small steady trickle of expected WARN/ERROR
+  - one injected incident: a burst of OOMKilled errors in payment-svc,
+    plus a brand-new template ("Database failover: replica %s promoted")
+    that the model has never seen before
+
+Run AFTER docker compose is up:
+
+    python seed_logs.py
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import requests
+
+CH_URL = "http://localhost:8123"
+DB = "demo"
+TABLE = "logs"
+
+random.seed(42)
+
+NOW = datetime.now(timezone.utc)
+WINDOW_MINUTES = 60
+ROWS_PER_MINUTE = 250
+
+
+SERVICES = ["auth-svc", "payment-svc", "checkout-svc"]
+
+NORMAL_TEMPLATES = [
+    ("auth-svc",     "info",  lambda: f"User {random.randint(1000, 9999)} logged in from {_ip()}"),
+    ("auth-svc",     "info",  lambda: f"Issued JWT for user {random.randint(1000, 9999)}"),
+    ("auth-svc",     "info",  lambda: f"GET /me 200 in {random.randint(2, 40)}ms"),
+    ("payment-svc",  "info",  lambda: f"Charged ${random.randint(5, 800)}.{random.randint(0, 99):02d} for order {uuid.uuid4()}"),
+    ("payment-svc",  "info",  lambda: f"Stripe webhook processed event={_event()}"),
+    ("checkout-svc", "info",  lambda: f"GET /cart 200 in {random.randint(3, 25)}ms"),
+    ("checkout-svc", "info",  lambda: f"Added item sku-{random.randint(100, 999)} to cart {uuid.uuid4()}"),
+    ("checkout-svc", "info",  lambda: f"Cache hit for product sku-{random.randint(100, 999)}"),
+]
+
+EXPECTED_NOISE = [
+    ("auth-svc",     "warn",  lambda: f"Slow login query: {random.randint(200, 900)}ms for user {random.randint(1000, 9999)}"),
+    ("payment-svc",  "warn",  lambda: f"Stripe retry attempt {random.randint(1, 3)} for charge {uuid.uuid4()}"),
+    ("checkout-svc", "error", lambda: f"Inventory check failed for sku-{random.randint(100, 999)}: temporary 503"),
+]
+
+
+def _ip() -> str:
+    return f"{random.randint(10, 200)}.{random.randint(0, 255)}.{random.randint(0, 255)}.{random.randint(0, 255)}"
+
+
+def _event() -> str:
+    return random.choice(["payment_intent.succeeded", "charge.succeeded", "invoice.paid"])
+
+
+def _row(ts: datetime, service: str, level: str, message: str) -> dict:
+    return {
+        "timestamp": ts.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3],
+        "service":   service,
+        "level":     level,
+        "message":   message,
+    }
+
+
+def generate_normal_window() -> list[dict]:
+    rows: list[dict] = []
+    start = NOW - timedelta(minutes=WINDOW_MINUTES)
+    for minute in range(WINDOW_MINUTES):
+        ts_minute = start + timedelta(minutes=minute)
+        for _ in range(ROWS_PER_MINUTE):
+            offset_ms = random.randint(0, 59_999)
+            ts = ts_minute + timedelta(milliseconds=offset_ms)
+            if random.random() < 0.03:
+                svc, lvl, mk = random.choice(EXPECTED_NOISE)
+            else:
+                svc, lvl, mk = random.choice(NORMAL_TEMPLATES)
+            rows.append(_row(ts, svc, lvl, mk()))
+    return rows
+
+
+def generate_incident_burst() -> list[dict]:
+    """An OOMKilled storm plus one never-before-seen template in payment-svc."""
+    rows: list[dict] = []
+    burst_start = NOW - timedelta(minutes=2)
+    for i in range(180):
+        ts = burst_start + timedelta(milliseconds=i * 600)
+        rows.append(_row(
+            ts, "payment-svc", "error",
+            f"OOMKilled in payment-svc pod payment-{random.randint(1, 8)} container=stripe-worker memory=4096Mi",
+        ))
+    for i in range(8):
+        ts = burst_start + timedelta(seconds=i * 7)
+        rows.append(_row(
+            ts, "payment-svc", "error",
+            f"Database failover: replica db-replica-{random.randint(1, 3)} promoted to primary after primary heartbeat lost",
+        ))
+    return rows
+
+
+def insert(rows: list[dict]) -> None:
+    payload = "\n".join(json.dumps(r) for r in rows)
+    r = requests.post(
+        f"{CH_URL}/?query=INSERT%20INTO%20{DB}.{TABLE}%20FORMAT%20JSONEachRow",
+        data=payload.encode("utf-8"),
+        headers={"Content-Type": "text/plain; charset=utf-8"},
+        timeout=120,
+    )
+    r.raise_for_status()
+
+
+def wait_for_clickhouse() -> None:
+    for _ in range(60):
+        try:
+            r = requests.get(f"{CH_URL}/?query=SELECT%201", timeout=2)
+            if r.ok and r.text.strip() == "1":
+                return
+        except Exception:
+            pass
+        time.sleep(1)
+    raise SystemExit("ClickHouse did not come up in 60s. Did you run `docker compose up`?")
+
+
+def main() -> None:
+    wait_for_clickhouse()
+    normal = generate_normal_window()
+    incident = generate_incident_burst()
+    print(f"Inserting {len(normal):,} normal rows ...")
+    insert(normal)
+    print(f"Inserting {len(incident):,} incident-burst rows ...")
+    insert(incident)
+    print(f"Done. Total rows in demo.logs: {len(normal) + len(incident):,}")
+
+
+if __name__ == "__main__":
+    main()

--- a/example-setups/logfile-quickstart/README.md
+++ b/example-setups/logfile-quickstart/README.md
@@ -1,0 +1,118 @@
+# Log-file quickstart — run anomaly detection on a downloaded `.log` file
+
+You already have a logging tool (Datadog, CloudWatch, Loki, …). You don't want to
+wire up API keys just to *see if this is worth it*. So: **download a log file,
+drop it here, run one command.** No database, no agent, no account, nothing
+leaves your machine.
+
+This is the fastest way to try Rocketgraph ML — and it's the same engine and the
+same endpoints you'd later point at a live source.
+
+---
+
+## TL;DR
+
+```bash
+cd example-setups/logfile-quickstart
+
+# Use your own export…
+cp ~/Downloads/your-logs.log ./logs/app.log
+#   …or generate a realistic sample with an incident baked in:
+python gen_sample_log.py
+
+docker compose up --build -d      # ML engine on http://localhost:9020
+bash run.sh                       # cluster + detect, pretty-printed
+```
+
+That's it. `run.sh` clusters the whole file into a handful of templates and then
+scores brand-new lines against the trained model.
+
+---
+
+## Getting a log file out of Datadog
+
+Any of these work — the connector auto-detects the format:
+
+| How you exported | File looks like | `FILE_FORMAT` |
+| --- | --- | --- |
+| **Logs UI → Export → CSV** | `Date,Service,Status,Message` rows | `auto` (or `csv`) |
+| **Logs API / Log Forwarder** | one JSON object per line (NDJSON), fields under `attributes` | `auto` (or `json`) |
+| **Raw app log / `kubectl logs > app.log`** | plain text lines | `auto` (or `text`) |
+
+Drop the file at `./logs/app.log` (or change `FILE_PATH` in `docker-compose.yml`
+to match your filename). The whole file is treated as the analysis window — you
+don't pass a time range, because a downloaded snapshot is already the slice you
+care about.
+
+> No Datadog handy? Run `python gen_sample_log.py` to write a 15k-line sample
+> across three services with a 2-minute incident hiding at the end (an OOM burst
+> and a brand-new "database failover" template the model has never seen).
+> Use `--format csv` or `--format text` to try the other shapes.
+
+---
+
+## What you'll see
+
+**Step 1 — cluster the file and train the detector**
+
+```bash
+curl -X POST 'http://localhost:9020/clusters/train?source=file' | jq
+```
+
+~15,000 raw lines collapse to ~11 structural templates. The brand-new failover
+template — 8 lines, never seen before, error level — comes back flagged as an
+anomaly cluster. No rules written, no labels.
+
+**Step 2 — score new lines as they arrive**
+
+```bash
+curl -X POST 'http://localhost:9020/anomalies/detect' \
+  -H 'Content-Type: application/json' \
+  -d '{"logs":[{"timestamp":1716624000000,"service":"payment-svc","level":"error",
+        "message":"TLS handshake failed with upstream vault-proxy after 3 retries"}]}'
+```
+
+A never-before-seen error returns with `reasons: ["anomaly_score","new_template"]`
+and an HST score around `0.9`. A routine login line is dropped. That `reasons`
+array is what you route on — `new_template` → Jira, `error_burst` → page oncall.
+
+---
+
+## Pointing at your own file
+
+Edit `docker-compose.yml`:
+
+```yaml
+volumes:
+  - ./logs:/data:ro
+environment:
+  FILE_PATH:    /data/app.log     # the file inside the container
+  FILE_FORMAT:  auto              # auto | json | csv | text
+  FILE_SERVICE: payment-svc       # optional fallback when a line has no service
+```
+
+Or set it at runtime without touching compose:
+
+```bash
+curl -X POST http://localhost:9020/credentials \
+  -H 'Content-Type: application/json' \
+  -d '{"source":"file","credentials":{"path":"/data/other.log","format":"text"}}'
+```
+
+---
+
+## Tuning
+
+| Env var | Default | Effect |
+| --- | --- | --- |
+| `DRAIN_SIM_TH` | `0.4` | lower → fewer, broader templates |
+| `ANOMALY_CONTAMINATION` | `0.1` | expected fraction of anomalous templates |
+| `HST_THRESHOLD` | `0.7` | streaming score cutoff (raise to 0.8 for fewer alerts) |
+
+---
+
+## Next step: point it at the live source
+
+When the file run convinces you, swap `source=file` for `source=datadog` (or
+loki, cloudwatch, sentry, clickhouse, newrelic) and give it credentials — the
+endpoints are identical. See [`../../ml/README.md`](../../ml/README.md).

--- a/example-setups/logfile-quickstart/docker-compose.yml
+++ b/example-setups/logfile-quickstart/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  ml:
+    image: rocketgraph-ml:latest
+    build:
+      context: ../../ml
+    container_name: rg-logfile-ml
+    ports:
+      - "9020:9020"
+    volumes:
+      # Mount your log file(s) read-only into the container at /data.
+      # Drop your own export into ./logs/ (any .log / .json / .ndjson / .csv).
+      - ./logs:/data:ro
+    environment:
+      # Point the file connector at the log file inside the container.
+      FILE_PATH: /data/app.log
+      FILE_FORMAT: auto          # auto | json | csv | text
+      # FILE_SERVICE: my-service # optional fallback service name
+      DRAIN_SIM_TH: "0.4"
+      HST_THRESHOLD: "0.7"
+      ANOMALY_CONTAMINATION: "0.1"
+      MAX_ROWS: "500000"

--- a/example-setups/logfile-quickstart/gen_sample_log.py
+++ b/example-setups/logfile-quickstart/gen_sample_log.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+Generate a realistic sample log file so you can try the file connector without
+your own data. Mimics a Datadog log export: newline-delimited JSON, one object
+per line, fields under an `attributes` block — exactly what you get from
+Datadog's Logs API / Log Forwarder.
+
+~15k boring-but-normal lines across three services, plus a 2-minute incident
+hiding at the end (an OOM burst and a brand-new "database failover" template the
+model has never seen). Run it, then `docker compose up` and `bash run.sh`.
+
+    python gen_sample_log.py            # → ./logs/app.log  (Datadog JSON)
+    python gen_sample_log.py --format csv
+    python gen_sample_log.py --format text
+
+Already have your own export? Skip this and just drop it at ./logs/app.log.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import random
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+random.seed(42)
+
+NORMAL_SERVICES = ["auth-svc", "checkout-svc", "payment-svc"]
+
+
+def normal_message(svc: str) -> str:
+    if svc == "auth-svc":
+        return random.choice([
+            f"User {random.randint(1000, 9999)} logged in from 10.0.{random.randint(0,255)}.{random.randint(0,255)}",
+            f"Token refreshed for session {random.randint(100000, 999999)}",
+            f"Password check passed for user {random.randint(1000, 9999)}",
+        ])
+    if svc == "checkout-svc":
+        return random.choice([
+            f"GET /api/v1/cart/{random.randint(1, 5000)} 200 {random.randint(8, 95)}ms",
+            f"cache hit for key product:{random.randint(1, 999)}",
+            f"Order {random.randint(10000, 99999)} created with {random.randint(1, 8)} items",
+        ])
+    return random.choice([  # payment-svc
+        f"Charge {random.randint(100000, 999999)} authorized for ${random.randint(5, 500)}.{random.randint(0,99):02d}",
+        f"POST /api/v1/payments 201 {random.randint(40, 220)}ms",
+        f"Stripe webhook processed event evt_{random.randint(100000, 999999)}",
+    ])
+
+
+def build_rows():
+    now = datetime.now(timezone.utc)
+    rows = []  # (ts_dt, service, level, message)
+
+    # ── ~15k normal logs spread across the last hour ──
+    for i in range(15000):
+        ts = now - timedelta(minutes=60) + timedelta(milliseconds=i * 240)
+        svc = random.choice(NORMAL_SERVICES)
+        rows.append((ts, svc, "info", normal_message(svc)))
+
+    # ── injected incident in the last 2 minutes ──
+    # 180 OOMKilled errors in payment-svc
+    for i in range(180):
+        ts = now - timedelta(minutes=2) + timedelta(milliseconds=i * 600)
+        rows.append((ts, "payment-svc", "error",
+                     f"OOMKilled in payment-svc pod payment-{random.randint(1,9)} "
+                     f"container=stripe-worker memory=4096Mi"))
+    # 8 lines of a brand-new template the model has never seen
+    for i in range(8):
+        ts = now - timedelta(minutes=1) + timedelta(seconds=i * 5)
+        rows.append((ts, "payment-svc", "error",
+                     f"Database failover: replica db-replica-{i} promoted to primary "
+                     f"after primary heartbeat lost"))
+
+    rows.sort(key=lambda r: r[0])
+    return rows
+
+
+def write_json(rows, path: Path):
+    with path.open("w", encoding="utf-8") as f:
+        for ts, svc, level, msg in rows:
+            f.write(json.dumps({"attributes": {
+                "timestamp": ts.isoformat(),
+                "status":    level,
+                "service":   svc,
+                "message":   msg,
+            }}) + "\n")
+
+
+def write_csv(rows, path: Path):
+    with path.open("w", encoding="utf-8", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["Date", "Service", "Status", "Message"])
+        for ts, svc, level, msg in rows:
+            w.writerow([ts.isoformat(), svc, level, msg])
+
+
+def write_text(rows, path: Path):
+    with path.open("w", encoding="utf-8") as f:
+        for ts, svc, level, msg in rows:
+            f.write(f"{ts.strftime('%Y-%m-%dT%H:%M:%S.%fZ')} {level.upper()} "
+                    f"service={svc} {msg}\n")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--format", choices=["json", "csv", "text"], default="json")
+    ap.add_argument("--out", default=str(Path(__file__).parent / "logs" / "app.log"))
+    args = ap.parse_args()
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    rows = build_rows()
+    {"json": write_json, "csv": write_csv, "text": write_text}[args.format](rows, out)
+
+    print(f"Wrote {len(rows):,} log lines → {out}  (format={args.format})")
+    print("Now run:  docker compose up --build   then   bash run.sh")
+
+
+if __name__ == "__main__":
+    main()

--- a/example-setups/logfile-quickstart/logs/.gitignore
+++ b/example-setups/logfile-quickstart/logs/.gitignore
@@ -1,0 +1,6 @@
+app.log
+*.log
+*.json
+*.ndjson
+*.csv
+!.gitkeep

--- a/example-setups/logfile-quickstart/run.sh
+++ b/example-setups/logfile-quickstart/run.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Point Rocketgraph at a downloaded .log file and get value in one shot.
+#
+#   1. docker compose up --build      (starts the ML engine, mounts ./logs)
+#   2. bash run.sh                     (this script)
+#
+# No database, no agent, no account. The file IS the analysis window.
+#
+set -euo pipefail
+
+ML="${ML:-http://localhost:9020}"
+
+echo
+echo "==> Waiting for the ML engine..."
+until curl -sf "$ML/health" >/dev/null 2>&1; do sleep 1; done
+echo "    up."
+
+echo
+echo "==> 1. Cluster the whole log file + train the streaming detector"
+echo "       (source=file — reads the file mounted at FILE_PATH)"
+echo
+curl -s -X POST "$ML/clusters/train?source=file" | jq '{
+  log_count,
+  cluster_count,
+  compression: "\(.log_count) raw logs → \(.cluster_count) templates",
+  anomaly_clusters: [
+    .clusters[] | select(.isAnomaly == true)
+    | {service, template, logCount, isolationDepth}
+  ]
+}'
+
+echo
+echo "==> 2. Score brand-new log lines against the trained model"
+echo "       (these lines are NOT in the file — a fresh incident arriving live)"
+echo
+curl -s -X POST "$ML/anomalies/detect" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "logs": [
+          {
+            "timestamp": '"$(($(date +%s) * 1000))"',
+            "service":   "payment-svc",
+            "level":     "error",
+            "message":   "TLS handshake failed with upstream vault-proxy after 3 retries"
+          },
+          {
+            "timestamp": '"$(($(date +%s) * 1000))"',
+            "service":   "auth-svc",
+            "level":     "info",
+            "message":   "User 4242 logged in from 10.0.0.1"
+          }
+        ]
+      }' | jq '{
+        scored,
+        anomaly_count,
+        anomalies: [.anomalies[] | {service, reasons, hst_score, message}]
+      }'
+
+echo
+echo "The boring login line was dropped. The never-before-seen error came back"
+echo "with reasons stacked — route 'new_template' to Jira, 'error_burst' to oncall."
+echo

--- a/ml/.env.example
+++ b/ml/.env.example
@@ -40,6 +40,11 @@
 # CH_COL_LEVEL=level
 # CH_COL_SERVICE=service
 
+# ── Log file (.log / .json / .csv on disk) ───────────────────────────────────
+# FILE_PATH=/data/app.log       # path to the file (mount it into the container)
+# FILE_FORMAT=auto              # auto | json | csv | text
+# FILE_SERVICE=                 # optional fallback service name (default: file stem)
+
 # ── ML knobs ─────────────────────────────────────────────────────────────────
 # DRAIN_SIM_TH=0.4
 # ANOMALY_CONTAMINATION=0.1

--- a/ml/README.md
+++ b/ml/README.md
@@ -42,7 +42,7 @@ All four are deterministic given the same input. The same window of logs produce
 ```
        ┌───────────────────────────────────────────────────────────┐
        │  Source of record  (Loki / NR / Datadog / CloudWatch /    │
-       │                     Sentry / ClickHouse)                  │
+       │              Sentry / ClickHouse / .log file)             │
        └────────────────────────────┬──────────────────────────────┘
                                     │ pull window (1h | 1d | 7d | absolute)
                                     ▼
@@ -209,7 +209,31 @@ Rocketgraph connects to your existing source of record directly — no data dupl
 | **AWS CloudWatch** | IAM keys | `access_key_id`, `secret_access_key`, `region`, `log_group`, `log_stream` (opt.) |
 | **Sentry** | User auth token | `token` (sntrys_…), `org`, `project` |
 | **ClickHouse** | HTTP basic auth | `url`, `user`, `password`, `database`, `table`, `col_timestamp`, `col_message`, `col_level`, `col_service` |
+| **Log file** | none (local file) | `path`, `format` (`auto`\|`json`\|`csv`\|`text`), `service` |
 | **OpenTelemetry** | OTLP collector | Route into ClickHouse or Loki, then point Rocketgraph at that. See [Routing OpenTelemetry into Rocketgraph](#routing-opentelemetry-into-rocketgraph) below. |
+
+### `source=file` — point at a `.log` file on disk
+
+The zero-infrastructure path. Export logs from whatever you already run (Datadog
+CSV/JSON, `kubectl logs > app.log`, a raw application log), drop the file next to
+the engine, and analyse it with no credentials and no data leaving your machine.
+
+```bash
+# mount the file into the container, then:
+curl -XPOST 'http://localhost:9020/clusters/train?source=file'
+```
+
+```env
+FILE_PATH=/data/app.log     # required — path to the file
+FILE_FORMAT=auto            # auto | json | csv | text  (auto-detects)
+FILE_SERVICE=payment-svc    # optional fallback service name
+```
+
+The connector auto-detects three shapes: Datadog-style NDJSON (fields under an
+`attributes` block), a single JSON array, CSV with a header row, or plain text
+(it sniffs the leading timestamp, level, and `service=` tag per line). The whole
+file is the analysis window — no time range needed. See the runnable
+[log-file quickstart](../example-setups/logfile-quickstart/).
 
 All connectors return the same row shape, so the downstream ML pipeline is identical regardless of source:
 
@@ -344,6 +368,7 @@ Rocketgraph is designed to run inside your network.
 
 | Platform | Status |
 | --- | --- |
+| Log file (`.log` / `.json` / `.csv`) | Supported |
 | OpenTelemetry (logs) | Supported |
 | Grafana Loki | Supported |
 | New Relic | Supported |

--- a/ml/app.py
+++ b/ml/app.py
@@ -4,7 +4,7 @@ Rocketgraph ML — Drain3 clustering + Half-Space-Trees anomaly detection.
 Endpoints
 ─────────
   GET  /clusters
-         ?source=loki|newrelic|datadog|cloudwatch|sentry|clickhouse
+         ?source=loki|newrelic|datadog|cloudwatch|sentry|clickhouse|file
          &window=1h|6h|12h|24h|1d|7d|custom
          &hours=<int>   (when window=custom)
          → Drain3 templates + Isolation-Forest anomaly scores per cluster.
@@ -156,7 +156,7 @@ def _fetch(
 
 @app.get("/clusters", summary="Drain3 clusters + isolation-forest anomalies")
 def get_clusters(
-    source: str        = Query(..., description="loki | newrelic | datadog | cloudwatch | sentry | clickhouse"),
+    source: str        = Query(..., description="loki | newrelic | datadog | cloudwatch | sentry | clickhouse | file"),
     window: str        = Query("6h", description="1h | 6h | 12h | 24h | 1d | 7d | custom"),
     hours:  int | None = Query(None, description="Custom lookback in hours (when window=custom)"),
     start:  str | None = Query(None, description="Absolute ISO-8601 start (UTC). Overrides window. ClickHouse only."),

--- a/ml/config.py
+++ b/ml/config.py
@@ -58,6 +58,11 @@ class Settings(BaseSettings):
     ch_col_level:      str = "level"
     ch_col_service:    str = "service"
 
+    # ── File (.log on disk) ───────────────────────────────────────────────────
+    file_path:    str = ""
+    file_format:  str = "auto"   # auto | json | text
+    file_service: str = ""        # fallback service name; defaults to file stem
+
     # ── ML knobs ──────────────────────────────────────────────────────────────
     drain_sim_th:          float = 0.4
     anomaly_contamination: float = 0.1
@@ -97,6 +102,11 @@ _CRED_FIELDS = {
         ("token",   "sentry_auth_token"),
         ("org",     "sentry_org"),
         ("project", "sentry_project"),
+    ],
+    "file": [
+        ("path",    "file_path"),
+        ("format",  "file_format"),
+        ("service", "file_service"),
     ],
     "clickhouse": [
         ("url",            "ch_url"),
@@ -161,6 +171,7 @@ def configured_sources() -> dict[str, bool]:
         "cloudwatch": ["access_key_id", "secret_access_key", "log_group"],
         "sentry":     ["token", "org", "project"],
         "clickhouse": ["url"],
+        "file":       ["path"],
     }
     out: dict[str, bool] = {}
     for src, fields in required.items():

--- a/ml/connectors/__init__.py
+++ b/ml/connectors/__init__.py
@@ -11,7 +11,7 @@ those kwargs and use the rolling lookback. Each row is:
 from datetime import datetime
 from typing import Optional
 
-from . import cloudwatch, clickhouse, datadog, loki, newrelic, sentry
+from . import cloudwatch, clickhouse, datadog, file, loki, newrelic, sentry
 
 REGISTRY = {
     "newrelic":   newrelic.fetch_logs,
@@ -20,6 +20,7 @@ REGISTRY = {
     "cloudwatch": cloudwatch.fetch_logs,
     "sentry":     sentry.fetch_logs,
     "clickhouse": clickhouse.fetch_logs,
+    "file":       file.fetch_logs,
 }
 
 # Connectors that accept absolute (start, end) datetimes via kwargs.

--- a/ml/connectors/file.py
+++ b/ml/connectors/file.py
@@ -1,0 +1,356 @@
+"""
+File connector — point Rocketgraph at a `.log` file on disk and get value with
+zero infrastructure. Built for the "download your logs and run it" workflow:
+export from Datadog (or anything else), drop the file next to the engine, done.
+
+It auto-detects the three shapes a downloaded log file usually arrives in:
+
+  1. Datadog JSON export — one JSON object per line (NDJSON), with fields under
+     a top-level `attributes` block: {"attributes": {"timestamp", "message",
+     "status", "service", ...}}. Also handles a single JSON array of such rows.
+  2. Generic NDJSON / JSON array — top-level {"message"|"msg"|"log",
+     "level"|"status"|"severity", "service", "timestamp"|"date"|"@timestamp"}.
+  3. CSV export — Datadog's UI "Export to CSV" and similar. A header row names
+     the columns (Date / Message / Service / Status / Host …); we map them to the
+     normalised shape.
+  4. Plain text — raw application log lines. We best-effort sniff the leading
+     timestamp, the level (info/warn/error/...), and a service tag, then hand the
+     line to Drain which masks the variable bits anyway.
+
+The whole file is treated as the analysis window — `lookback_hours` is ignored,
+because a downloaded snapshot is already the slice the user cares about.
+
+credentials keys:
+    path     – path to the .log / .json / .ndjson / .csv file   (required)
+    format   – auto | json | csv | text                         (default: auto)
+    service  – fallback service name when a line/row has none
+               (default: the file stem, e.g. "payment-svc.log" → "payment-svc")
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import logging
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+# ── level normalisation ───────────────────────────────────────────────────────
+_LEVEL_NORM = {
+    "warning":  "warn",
+    "err":      "error",
+    "critical": "error",
+    "crit":     "error",
+    "fatal":    "error",
+    "emerg":    "error",
+    "alert":    "error",
+    "trace":    "debug",
+    "notice":   "info",
+    "ok":       "info",
+}
+_LEVEL_RE = re.compile(
+    r'\b(debug|info|warn(?:ing)?|error|err|crit(?:ical)?|fatal|trace)\b', re.I
+)
+
+# ── timestamp sniffing for plain-text lines ───────────────────────────────────
+# Each pattern captures the timestamp text at the start of (or early in) a line.
+_TS_PATTERNS = [
+    # 2026-05-29T10:00:00.123Z  /  2026-05-29 10:00:00,123  /  +00:00 offsets
+    re.compile(r'(?P<ts>\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?:[.,]\d+)?(?:Z|[+-]\d{2}:?\d{2})?)'),
+    # [2026-05-29 10:00:00]
+    re.compile(r'\[(?P<ts>\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?:[.,]\d+)?)\]'),
+    # epoch millis or seconds at the very start
+    re.compile(r'^(?P<ts>\d{10,13})\b'),
+    # syslog: May 29 10:00:00
+    re.compile(r'^(?P<ts>[A-Z][a-z]{2}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})'),
+]
+
+_SERVICE_PATTERNS = [
+    re.compile(r'\bservice[=:]\s*"?([\w.\-]+)"?', re.I),
+    re.compile(r'\b(?:svc|app|logger|component)[=:]\s*"?([\w.\-]+)"?', re.I),
+]
+
+
+def _normalise_level(raw: str) -> str:
+    v = (raw or "").strip().lower()
+    return _LEVEL_NORM.get(v, v) if v else "info"
+
+
+def _level_from_text(line: str) -> str:
+    m = _LEVEL_RE.search(line)
+    if not m:
+        return "info"
+    return _LEVEL_NORM.get(m.group(1).lower(), m.group(1).lower())
+
+
+def _to_ms(value) -> int | None:
+    """Best-effort convert an int/float/str timestamp to epoch milliseconds."""
+    if value is None:
+        return None
+    # numeric epoch
+    if isinstance(value, (int, float)):
+        n = float(value)
+    else:
+        s = str(value).strip()
+        if not s:
+            return None
+        if s.isdigit():
+            n = float(s)
+        else:
+            # ISO-8601 (with or without trailing Z / offset)
+            try:
+                dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
+                return int(dt.timestamp() * 1000)
+            except ValueError:
+                # syslog-style "May 29 10:00:00" — no year; assume current year
+                for fmt in ("%b %d %H:%M:%S", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M:%S,%f"):
+                    try:
+                        dt = datetime.strptime(s, fmt).replace(tzinfo=timezone.utc)
+                        return int(dt.timestamp() * 1000)
+                    except ValueError:
+                        continue
+                return None
+    # numeric: decide s vs ms vs µs vs ns by magnitude
+    if n >= 1e16:        # nanoseconds
+        return int(n / 1e6)
+    if n >= 1e13:        # microseconds
+        return int(n / 1e3)
+    if n >= 1e11:        # milliseconds
+        return int(n)
+    return int(n * 1000)  # seconds
+
+
+# ── JSON row extraction (Datadog export + generic) ────────────────────────────
+_MSG_KEYS   = ("message", "msg", "log", "text", "content", "body")
+_LEVEL_KEYS = ("status", "level", "severity", "loglevel", "log_level", "syslog.severity")
+_SVC_KEYS   = ("service", "svc", "app", "source", "logger", "ddsource")
+_TS_KEYS    = ("timestamp", "date", "time", "@timestamp", "_time", "datetime")
+
+
+def _dig(obj: dict, keys: tuple[str, ...]):
+    """Look up the first present key at top level, then inside `attributes`."""
+    for k in keys:
+        if k in obj and obj[k] not in (None, ""):
+            return obj[k]
+    attrs = obj.get("attributes")
+    if isinstance(attrs, dict):
+        for k in keys:
+            if k in attrs and attrs[k] not in (None, ""):
+                return attrs[k]
+        # Datadog nests custom fields one more level under attributes.attributes
+        inner = attrs.get("attributes")
+        if isinstance(inner, dict):
+            for k in keys:
+                if k in inner and inner[k] not in (None, ""):
+                    return inner[k]
+    return None
+
+
+def _row_from_json(obj: dict, default_service: str) -> dict | None:
+    if not isinstance(obj, dict):
+        return None
+    msg = _dig(obj, _MSG_KEYS)
+    if msg is None:
+        # nothing message-like — skip empty/metadata rows
+        return None
+    lvl_raw = _dig(obj, _LEVEL_KEYS)
+    level   = _normalise_level(str(lvl_raw)) if lvl_raw else _level_from_text(str(msg))
+    svc     = _dig(obj, _SVC_KEYS) or default_service
+    ts_ms   = _to_ms(_dig(obj, _TS_KEYS))
+    return {
+        "timestamp": ts_ms,                 # may be None → filled in later
+        "message":   str(msg),
+        "level":     level,
+        "service":   str(svc),
+    }
+
+
+def _row_from_text(line: str, default_service: str) -> dict:
+    ts_ms: int | None = None
+    message = line
+    for pat in _TS_PATTERNS:
+        m = pat.search(line)
+        if m:
+            ts_ms = _to_ms(m.group("ts"))
+            if ts_ms is not None:
+                # strip a leading timestamp so templates stay clean
+                if m.start() <= 1:
+                    message = line[m.end():].lstrip(" -|]\t")
+                break
+    service = default_service
+    for pat in _SERVICE_PATTERNS:
+        sm = pat.search(line)
+        if sm:
+            service = sm.group(1)
+            break
+    return {
+        "timestamp": ts_ms,
+        "message":   message or line,
+        "level":     _level_from_text(line),
+        "service":   service,
+    }
+
+
+def _detect_format(sample_lines: list[str]) -> str:
+    for ln in sample_lines:
+        s = ln.strip()
+        if not s:
+            continue
+        if s[0] in "[{":
+            return "json"
+        # CSV: a comma-separated header naming at least one known column
+        if "," in s:
+            header = {h.strip().strip('"').lower() for h in s.split(",")}
+            known = set(_MSG_KEYS) | set(_LEVEL_KEYS) | set(_SVC_KEYS) | set(_TS_KEYS)
+            if header & known:
+                return "csv"
+        return "text"
+    return "text"
+
+
+def _parse_csv(text: str, default_service: str) -> list[dict]:
+    reader = csv.DictReader(io.StringIO(text))
+    if not reader.fieldnames:
+        return []
+    # case-insensitive column lookup
+    lower_map = {(name or "").strip().lower(): name for name in reader.fieldnames}
+
+    def pick(keys: tuple[str, ...]):
+        for k in keys:
+            if k in lower_map:
+                return lower_map[k]
+        return None
+
+    col_msg = pick(_MSG_KEYS)
+    col_lvl = pick(_LEVEL_KEYS)
+    col_svc = pick(_SVC_KEYS)
+    col_ts  = pick(_TS_KEYS)
+
+    rows: list[dict] = []
+    for rec in reader:
+        msg = (rec.get(col_msg) if col_msg else None)
+        if not msg:
+            # no dedicated message column — join the row so Drain still sees content
+            msg = " ".join(str(v) for v in rec.values() if v)
+        if not msg:
+            continue
+        lvl_raw = rec.get(col_lvl) if col_lvl else None
+        level   = _normalise_level(str(lvl_raw)) if lvl_raw else _level_from_text(str(msg))
+        svc     = (rec.get(col_svc) if col_svc else None) or default_service
+        ts_ms   = _to_ms(rec.get(col_ts)) if col_ts else None
+        rows.append({
+            "timestamp": ts_ms,
+            "message":   str(msg),
+            "level":     level,
+            "service":   str(svc),
+        })
+    return rows
+
+
+def _parse_json(text: str, default_service: str) -> list[dict]:
+    """Handle both a single JSON array and newline-delimited JSON."""
+    rows: list[dict] = []
+    stripped = text.lstrip()
+    if stripped.startswith("["):
+        try:
+            arr = json.loads(stripped)
+            if isinstance(arr, list):
+                for obj in arr:
+                    r = _row_from_json(obj, default_service)
+                    if r:
+                        rows.append(r)
+                return rows
+        except json.JSONDecodeError:
+            pass  # fall through to line-by-line
+    for ln in text.splitlines():
+        ln = ln.strip()
+        if not ln:
+            continue
+        try:
+            obj = json.loads(ln)
+        except json.JSONDecodeError:
+            continue
+        r = _row_from_json(obj, default_service)
+        if r:
+            rows.append(r)
+    return rows
+
+
+def _fill_timestamps(rows: list[dict]) -> None:
+    """Ensure every row has an epoch-ms timestamp so HST burst/first-seen logic
+    works. If most rows lack one, synthesise a monotonic stream ending ~now so
+    ordering (and therefore error bursts) is preserved. Otherwise forward-fill
+    the gaps from the nearest known timestamp."""
+    if not rows:
+        return
+    have = [i for i, r in enumerate(rows) if r["timestamp"] is not None]
+    now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+
+    if len(have) < len(rows) * 0.5:
+        base = now_ms - len(rows)
+        for i, r in enumerate(rows):
+            r["timestamp"] = base + i
+        return
+
+    # forward-fill, then back-fill any leading gap
+    last = None
+    for r in rows:
+        if r["timestamp"] is None:
+            r["timestamp"] = last if last is not None else now_ms
+        else:
+            last = r["timestamp"]
+    first_known = rows[have[0]]["timestamp"]
+    for i in range(have[0]):
+        rows[i]["timestamp"] = first_known
+
+
+def fetch_logs(credentials: dict, lookback_hours: int = 6, max_rows: int = 100_000) -> list[dict]:
+    path = credentials.get("path")
+    if not path:
+        raise RuntimeError("File connector requires credentials.path (path to the .log file)")
+
+    p = Path(path)
+    if not p.exists():
+        raise RuntimeError(f"File not found: {path}")
+    if not p.is_file():
+        raise RuntimeError(f"Not a file: {path}")
+
+    fmt             = (credentials.get("format") or "auto").strip().lower()
+    default_service = credentials.get("service") or p.stem or "unknown"
+
+    try:
+        text = p.read_text(encoding="utf-8", errors="replace")
+    except OSError as e:
+        raise RuntimeError(f"Could not read {path}: {e}")
+
+    if fmt == "auto":
+        fmt = _detect_format(text.splitlines()[:20])
+
+    if fmt == "json":
+        rows = _parse_json(text, default_service)
+        # a "json" file with no parseable objects → fall back to text
+        if not rows:
+            log.warning(f"[file] no JSON rows parsed from {path}; retrying as plain text")
+            fmt = "text"
+    elif fmt == "csv":
+        rows = _parse_csv(text, default_service)
+        if not rows:
+            log.warning(f"[file] no CSV rows parsed from {path}; retrying as plain text")
+            fmt = "text"
+    if fmt == "text":
+        rows = [
+            _row_from_text(ln, default_service)
+            for ln in text.splitlines()
+            if ln.strip()
+        ]
+
+    _fill_timestamps(rows)
+    rows = rows[:max_rows]
+    log.info(f"[file] {len(rows)} rows from {path} (format={fmt})")
+    return rows


### PR DESCRIPTION
Point Rocketgraph at a .log file on disk and run the existing Drain3 + Isolation Forest + Half-Space-Trees pipeline against it — no database, no agent, no credentials, nothing leaves the machine. Built for the "download your logs and run it" flow (e.g. a Datadog export).

The connector auto-detects four shapes and normalises to the standard {timestamp, message, level, service} row:
  - Datadog NDJSON export (fields under an `attributes` block)
  - Datadog CSV export (header row)
  - JSON array / generic NDJSON
  - plain text (sniffs leading timestamp, level, service= tag)

The whole file is the analysis window; missing timestamps are synthesised so burst/first-seen logic still works.

- ml/connectors/file.py: new connector
- registered as source=file in registry + config (FILE_PATH/FORMAT/SERVICE)
- example-setups/logfile-quickstart: one-command demo with sample generator
- docs: README, ml/README, .env.example updated